### PR TITLE
회원가입 api 연결 설정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,7 +36,7 @@ export type RootStackParamList = {
   DisasterNotiSettings: undefined;
   SignIn: undefined;
   SignUp: undefined;
-  SetName: undefined;
+  SetName: { id: string; email: string; password: string };
   SelectLocation: undefined;
   CompleteLogin: undefined;
 };

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -127,4 +127,4 @@ dependencies {
 }
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
-apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
+

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,3 +1,4 @@
 declare module '@env' {
   export const KAKAO_REST_API_KEY: string;
+  export const API_URL: string;
 }

--- a/ios/disaterkok_frontend/Info.plist
+++ b/ios/disaterkok_frontend/Info.plist
@@ -34,6 +34,8 @@
 				<true/>
 			</dict>
 		</dict>
+		<key>NSAllowsArbitraryLoads</key>
+    	<true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@react-navigation/bottom-tabs": "^6.5.9",
         "@react-navigation/native": "^6.1.8",
         "@react-navigation/native-stack": "^6.9.14",
+        "axios": "^1.6.1",
         "eslint-config-prettier": "^9.0.0",
         "react": "18.2.0",
         "react-native": "0.72.5",
@@ -5145,6 +5146,11 @@
         "has-symbols": "^1.0.3"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -5163,6 +5169,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -5813,6 +5829,17 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/command-exists": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
@@ -6196,6 +6223,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/denodeify": {
@@ -7528,12 +7563,44 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
+      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fresh": {
@@ -12095,6 +12162,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-navigation/bottom-tabs": "^6.5.9",
     "@react-navigation/native": "^6.1.8",
     "@react-navigation/native-stack": "^6.9.14",
+    "axios": "^1.6.1",
     "eslint-config-prettier": "^9.0.0",
     "react": "18.2.0",
     "react-native": "0.72.5",

--- a/src/apis/userAPI.ts
+++ b/src/apis/userAPI.ts
@@ -1,0 +1,28 @@
+import axios from 'axios';
+import { USER_API } from '../config/api';
+
+const userAPI = {
+  login: async (id: string, password: string) => {
+    const response = await axios.post(USER_API.LOGIN, {
+      username: id,
+      password: password,
+    });
+    return response.data;
+  },
+  //   logout: async () => {
+  //     const response = await axios.post(USER_API.LOGOUT);
+  //     return response.data;
+  //   },
+  register: async (id: string, email: string, password: string, nickname: string) => {
+    console.log(USER_API.REGISTER);
+    const response = await axios.post(USER_API.REGISTER, {
+      username: id,
+      email: email,
+      password: password,
+      //nickname: nickname,
+    });
+    return response.data;
+  },
+};
+
+export default userAPI;

--- a/src/config/api.ts
+++ b/src/config/api.ts
@@ -1,0 +1,7 @@
+import { API_URL } from '@env';
+
+export const USER_API = {
+  LOGIN: `${API_URL}/login/`,
+  LOGOUT: `${API_URL}/logout/`,
+  REGISTER: `${API_URL}/register/`,
+};

--- a/src/pages/SetName.tsx
+++ b/src/pages/SetName.tsx
@@ -37,10 +37,11 @@ export default function SetName({ route, navigation }: SetNameScreenProps) {
       console.log(id, email, password, nickname);
       const response = await userAPI.register(id, email, password, nickname);
       console.log(response);
-      navigation.navigate('SelectLocation');
+      //navigation.navigate('SelectLocation');
     } catch (error) {
       console.log(error);
     }
+    navigation.navigate('SelectLocation');
   };
 
   useEffect(() => {

--- a/src/pages/SetName.tsx
+++ b/src/pages/SetName.tsx
@@ -4,10 +4,13 @@ import COLOR from '../constants/colors';
 import useInput from '../hooks/useInput';
 import { RootStackParamList } from '../../App';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import userAPI from '../apis/userAPI';
 
 type SetNameScreenProps = NativeStackScreenProps<RootStackParamList, 'SetName'>;
 
-export default function SetName({ navigation }: SetNameScreenProps) {
+export default function SetName({ route, navigation }: SetNameScreenProps) {
+  const { id, email, password } = route.params;
+  //console.log('check', id, email, password);
   const [inputNicknameFocused, setInputNicknameFocused] = useState(false);
 
   const [nickname, onChangeNickname] = useInput('');
@@ -29,8 +32,15 @@ export default function SetName({ navigation }: SetNameScreenProps) {
     else setCharError(false);
   };
 
-  const onSubmit = () => {
-    navigation.navigate('SelectLocation');
+  const onSubmit = async () => {
+    try {
+      console.log(id, email, password, nickname);
+      const response = await userAPI.register(id, email, password, nickname);
+      console.log(response);
+      navigation.navigate('SelectLocation');
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   useEffect(() => {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -80,11 +80,12 @@ export default function SignUp({ navigation }: SignUpScreenProps) {
   const onSubmit = () => {
     checkAllValidation(id, email, password);
     setCheckSubmit(true);
-    navigation.navigate('SetName');
+    navigation.navigate('SetName', { id: id, email: email, password: password });
   };
 
   useEffect(() => {
     checkActiveLoginButton();
+    
   }, [id, email, password, passwordConfirm]);
 
   return (


### PR DESCRIPTION
## 작업 내용

- env.local에 백엔드 주소(http://~)를 넣고 setName page에서 register 요청을 테스트 했습니다.
- signUp에서 setName으로 id, email, password를 params로 전달했습니다.

## 참고 사항

- ios에서는 http 요청을 허용하지 않아 info.plist에 설정을 추가했습니다.
- android를 빌드하다가 "../../node_modules/react-native-vector-icons/fonts.gradle" 가 두 번 선언되어있는 오류를 발견해 수정했습니다.

## 기타 사항

- 다음 지역, 알림설정 페이지가 로그인 상태가 아닐 때 접근 가능한데, register 이후 response를 받고 바로 로그인 처리를 해야할 것 같아 다음 지역, 알림설정 페이지를 옮겨야 할 것 같습니다!
- device -> erase all content and settings를 하면 login 상태를 해제할 수 있습니다.
- 아직 요청후 403에러를 받는 상황입니다..
