### PR TITLE
홈 - 제보 - 제보 상세페이지 네비게이션 적용 (중첩 네비게이션 구조 수정 작업)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,43 +1,10 @@
 import * as React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import {
-  Home,
-  Report,
-  SignIn,
-  SignUp,
-  Solution,
-  SetName,
-  SelectLocation,
-  DisasterNotiSettings,
-  CompleteLogin,
-  ReportArticleDetail,
-} from './src/pages';
-import Onboarding from './src/pages/Onboarding';
 import useAuth from './src/states/useAuth';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-
-export type RootTabParamList = {
-  Home: undefined;
-  Report: undefined;
-  Solution: undefined;
-};
-
-export type RootStackParamList = {
-  Onboarding: undefined;
-  DisasterNotiSettings: undefined;
-  SignIn: undefined;
-  SignUp: undefined;
-  SetName: undefined;
-  SelectLocation: undefined;
-  CompleteLogin: undefined;
-  ReportDetail: undefined;
-};
-
-const Tab = createBottomTabNavigator<RootTabParamList>();
-const Stack = createNativeStackNavigator<RootStackParamList>();
+import LoggedOutStack from './src/navigation/LoggedOutStack';
+import RootStackNavigator from './src/navigation/RootStackNavigator';
 
 function App() {
   const { isLoggedIn } = useAuth();
@@ -45,59 +12,7 @@ function App() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <BottomSheetModalProvider>
         <NavigationContainer>
-          {isLoggedIn ? (
-            <Tab.Navigator>
-              <Tab.Screen
-                name="Home"
-                component={Home}
-                options={{ headerShown: false, title: '홈' }}
-              />
-              <Tab.Screen name="Report" component={Report} options={{ title: '실시간 제보' }} />
-              <Tab.Screen name="Solution" component={Solution} options={{ title: '솔루션' }} />
-            </Tab.Navigator>
-          ) : (
-            <Stack.Navigator>
-              <Stack.Group>
-                <Stack.Screen
-                  name="Onboarding"
-                  component={Onboarding}
-                  options={{ headerShown: false }}
-                />
-                {/* 테스트 위해 임시로 설정한거 */}
-                <Stack.Screen
-                  name="DisasterNotiSettings"
-                  component={DisasterNotiSettings}
-                  options={{ title: '알림 설정' }}
-                />
-                <Stack.Screen
-                  name="SignIn"
-                  component={SignIn}
-                  options={{ headerShown: false, title: '로그인' }}
-                />
-                <Stack.Screen name="SignUp" component={SignUp} options={{ title: '회원가입' }} />
-                <Stack.Screen
-                  name="SetName"
-                  component={SetName}
-                  options={{ title: '닉네임 설정' }}
-                />
-                <Stack.Screen
-                  name="SelectLocation"
-                  component={SelectLocation}
-                  options={{ title: '지역 선택' }}
-                />
-                <Stack.Screen
-                  name="CompleteLogin"
-                  component={CompleteLogin}
-                  options={{ headerShown: false, title: '회원가입 완료' }}
-                />
-              </Stack.Group>
-              <Stack.Screen
-                name="ReportDetail"
-                component={ReportArticleDetail}
-                options={{ title: '제보 상세' }}
-              />
-            </Stack.Navigator>
-          )}
+          {isLoggedIn ? <RootStackNavigator /> : <LoggedOutStack />}
         </NavigationContainer>
       </BottomSheetModalProvider>
     </GestureHandlerRootView>

--- a/App.tsx
+++ b/App.tsx
@@ -18,7 +18,6 @@ import Onboarding from './src/pages/Onboarding';
 import useAuth from './src/states/useAuth';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import ReportPost from './src/pages/ReportPost';
 
 export type RootTabParamList = {
   Home: undefined;
@@ -53,7 +52,7 @@ function App() {
                 component={Home}
                 options={{ headerShown: false, title: '홈' }}
               />
-              <Tab.Screen name="Report" component={ReportPost} options={{ title: '실시간 제보' }} />
+              <Tab.Screen name="Report" component={Report} options={{ title: '실시간 제보' }} />
               <Tab.Screen name="Solution" component={Solution} options={{ title: '솔루션' }} />
             </Tab.Navigator>
           ) : (

--- a/src/components/BottomSheetModal/SelectDisasterBottomSheet.tsx
+++ b/src/components/BottomSheetModal/SelectDisasterBottomSheet.tsx
@@ -5,7 +5,7 @@ import COLOR from '../../constants/colors';
 import AntIcon from 'react-native-vector-icons/AntDesign';
 import { RootTabParamList } from '../../../App';
 import { NavigationProp } from '@react-navigation/native';
-import { CustomNavigationOptions } from '../../pages/Report';
+import { CustomNavigationOptions } from '../../pages/ReportList';
 import MainCategory from '../SelectDisaster/MainCategory';
 import { DisasterCategoryType, DisasterType } from '../SelectDisaster/types';
 import { DISASTER_CATEGORY } from '../../constants/DummyDisaster';

--- a/src/components/BottomSheetModal/SelectRegionBottomSheet.tsx
+++ b/src/components/BottomSheetModal/SelectRegionBottomSheet.tsx
@@ -8,7 +8,7 @@ import { RootTabParamList } from '../../../App';
 import { NavigationProp } from '@react-navigation/native';
 import { EupmyeondongTable, SidoTable, SigunguTable } from '../SelectRegion';
 import { SidoType, SigunguAndEupmyeondongType } from '../SelectRegion/types';
-import { CustomNavigationOptions } from '../../pages/Report';
+import { CustomNavigationOptions } from '../../pages/ReportList';
 
 type SelectRegionScreenProps = {
   bottomSheetModalRef: RefObject<BottomSheetModal>;

--- a/src/components/Header/HeadrLeftGoBack.tsx
+++ b/src/components/Header/HeadrLeftGoBack.tsx
@@ -1,0 +1,19 @@
+import { useNavigation } from '@react-navigation/native';
+import React from 'react';
+import { View } from 'react-native';
+import { Pressable } from 'react-native';
+import Icon from 'react-native-vector-icons/Ionicons';
+import COLOR from '../../constants/colors';
+
+const HeaderLeftGoBack = () => {
+  const navigation = useNavigation();
+  return (
+    <Pressable onPress={() => navigation.goBack()} hitSlop={8}>
+      <View>
+        <Icon size={24} name="chevron-back" color={COLOR.black} />
+      </View>
+    </Pressable>
+  );
+};
+
+export default HeaderLeftGoBack;

--- a/src/components/Home/IssueSection.tsx
+++ b/src/components/Home/IssueSection.tsx
@@ -35,5 +35,6 @@ const styles = StyleSheet.create({
         elevation: 5,
       },
     }),
+    marginBottom: 30,
   },
 });

--- a/src/components/Home/ReportSection.tsx
+++ b/src/components/Home/ReportSection.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import COLOR from '../../constants/colors';
+import ReportArticleList from '../ReportArticle/ReportArticleList';
+
+export default function ReportSection() {
+  return (
+    <View style={styles.reportWrapper}>
+      <View style={styles.titleContainer}>
+        <Text style={styles.title}>실시간 제보</Text>
+        <Text style={styles.subTitle}>시민들의 실시간 제보를 통해 재난을 확인해요</Text>
+      </View>
+      <ReportArticleList />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  reportWrapper: {},
+  titleContainer: {
+    gap: 5,
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  subTitle: {
+    fontSize: 10,
+    color: `${COLOR.gray}`,
+  },
+});

--- a/src/components/Home/ReportSection.tsx
+++ b/src/components/Home/ReportSection.tsx
@@ -1,16 +1,30 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import COLOR from '../../constants/colors';
 import ReportArticleList from '../ReportArticle/ReportArticleList';
+import AntIcon from 'react-native-vector-icons/AntDesign';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { HomeStackParamList } from '../../navigation/types';
+import { HomeScreenProps } from '../../pages/Home';
 
-export default function ReportSection() {
+// type ReportScreenProps = NativeStackScreenProps<HomeStackParamList, 'ReportList'>;
+
+export default function ReportSection({ navigation }: HomeScreenProps) {
+  const navigateToReportList = () => {
+    navigation.navigate('ReportList');
+  };
+
   return (
     <View style={styles.reportWrapper}>
       <View style={styles.titleContainer}>
         <Text style={styles.title}>실시간 제보</Text>
         <Text style={styles.subTitle}>시민들의 실시간 제보를 통해 재난을 확인해요</Text>
       </View>
-      <ReportArticleList />
+      <ReportArticleList navigation={navigation} />
+      <Pressable style={styles.moreView} onPress={navigateToReportList}>
+        <Text style={styles.moreViewText}>더보기</Text>
+        <AntIcon name="right" size={12} color={COLOR.gray} />
+      </Pressable>
     </View>
   );
 }
@@ -27,6 +41,17 @@ const styles = StyleSheet.create({
   },
   subTitle: {
     fontSize: 10,
+    color: `${COLOR.gray}`,
+  },
+  moreView: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 3,
+    marginTop: 50,
+  },
+  moreViewText: {
+    fontSize: 12,
     color: `${COLOR.gray}`,
   },
 });

--- a/src/components/Home/ReportSection.tsx
+++ b/src/components/Home/ReportSection.tsx
@@ -6,10 +6,10 @@ import AntIcon from 'react-native-vector-icons/AntDesign';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { HomeStackParamList } from '../../navigation/types';
 import { HomeScreenProps } from '../../pages/Home';
+import { useNavigation } from '@react-navigation/native';
 
-// type ReportScreenProps = NativeStackScreenProps<HomeStackParamList, 'ReportList'>;
-
-export default function ReportSection({ navigation }: HomeScreenProps) {
+export default function ReportSection() {
+  const navigation = useNavigation();
   const navigateToReportList = () => {
     navigation.navigate('ReportList');
   };
@@ -20,7 +20,7 @@ export default function ReportSection({ navigation }: HomeScreenProps) {
         <Text style={styles.title}>실시간 제보</Text>
         <Text style={styles.subTitle}>시민들의 실시간 제보를 통해 재난을 확인해요</Text>
       </View>
-      <ReportArticleList navigation={navigation} />
+      <ReportArticleList />
       <Pressable style={styles.moreView} onPress={navigateToReportList}>
         <Text style={styles.moreViewText}>더보기</Text>
         <AntIcon name="right" size={12} color={COLOR.gray} />

--- a/src/components/ReportArticle/ReportArticleCard.tsx
+++ b/src/components/ReportArticle/ReportArticleCard.tsx
@@ -13,9 +13,14 @@ export default function ReportArticleCard({
   likeCount,
   title,
   tags,
+  navigation,
 }: ReportArticleType) {
+  const navigateToReportDetail = () => {
+    navigation.navigate('ReportArticleDetail');
+  };
+
   return (
-    <Pressable style={styles.cardLayout}>
+    <Pressable style={styles.cardLayout} onPress={navigateToReportDetail}>
       <View style={styles.img}>
         <View style={styles.topContainer}>
           <View style={styles.topLeftContainer}>

--- a/src/components/ReportArticle/ReportArticleList.tsx
+++ b/src/components/ReportArticle/ReportArticleList.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { FlatList, StyleSheet } from 'react-native';
+import { ARTICLE_LIST } from '../../constants/DummyArticle';
+import ReportArticleCard from './ReportArticleCard';
+
+export default function ReportArticleList() {
+  return (
+    <FlatList
+      data={ARTICLE_LIST}
+      renderItem={({ item }) => (
+        <ReportArticleCard
+          id={item.id}
+          elapsedTime={item.elapsedTime}
+          viewCount={item.viewCount}
+          likeCount={item.likeCount}
+          title={item.title}
+          tags={item.tags}
+        />
+      )}
+      numColumns={1}
+      contentContainerStyle={styles.articleList}
+      scrollEnabled={false}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  articleList: {
+    gap: 10,
+  },
+});

--- a/src/components/ReportArticle/ReportArticleList.tsx
+++ b/src/components/ReportArticle/ReportArticleList.tsx
@@ -3,7 +3,10 @@ import { FlatList, StyleSheet } from 'react-native';
 import { ARTICLE_LIST } from '../../constants/DummyArticle';
 import ReportArticleCard from './ReportArticleCard';
 
-export default function ReportArticleList() {
+export default function ReportArticleList({ navigation }) {
+  const navigateToReportDetail = () => {
+    navigation.navigate('ReportArticleDetail');
+  };
   return (
     <FlatList
       data={ARTICLE_LIST}
@@ -15,6 +18,7 @@ export default function ReportArticleList() {
           likeCount={item.likeCount}
           title={item.title}
           tags={item.tags}
+          navigation={navigation}
         />
       )}
       numColumns={1}

--- a/src/components/ReportArticle/ReportArticleList.tsx
+++ b/src/components/ReportArticle/ReportArticleList.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import { FlatList, StyleSheet } from 'react-native';
 import { ARTICLE_LIST } from '../../constants/DummyArticle';
 import ReportArticleCard from './ReportArticleCard';
+import { useNavigation } from '@react-navigation/native';
+import HeaderLeftGoBack from '../Header/HeadrLeftGoBack';
 
-export default function ReportArticleList({ navigation }) {
+export default function ReportArticleList() {
+  const navigation = useNavigation();
   const navigateToReportDetail = () => {
     navigation.navigate('ReportArticleDetail');
   };
+
   return (
     <FlatList
       data={ARTICLE_LIST}

--- a/src/navigation/HomeStack.tsx
+++ b/src/navigation/HomeStack.tsx
@@ -2,6 +2,8 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import React from 'react';
 import { Home, ReportArticleDetail, ReportList } from '../pages';
 import { HomeStackParamList } from './types';
+import HeaderLeftGoBack from '../components/Header/HeadrLeftGoBack';
+import { Image } from 'react-native';
 
 const Stack = createNativeStackNavigator<HomeStackParamList>();
 
@@ -9,11 +11,18 @@ export default function HomeStack() {
   return (
     <Stack.Navigator>
       <Stack.Screen name="Home" component={Home} options={{ headerShown: false }} />
-      <Stack.Screen name="ReportList" component={ReportList} options={{ title: '실시간 제보' }} />
+      <Stack.Screen
+        name="ReportList"
+        component={ReportList}
+        options={{
+          title: '실시간 제보',
+          headerLeft: () => <HeaderLeftGoBack />,
+        }}
+      />
       <Stack.Screen
         name="ReportArticleDetail"
         component={ReportArticleDetail}
-        options={{ title: '실시간 제보' }}
+        options={{ title: '실시간 제보', headerLeft: () => <HeaderLeftGoBack /> }}
       />
     </Stack.Navigator>
   );

--- a/src/navigation/HomeStack.tsx
+++ b/src/navigation/HomeStack.tsx
@@ -1,0 +1,20 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import React from 'react';
+import { Home, ReportArticleDetail, ReportList } from '../pages';
+import { HomeStackParamList } from './types';
+
+const Stack = createNativeStackNavigator<HomeStackParamList>();
+
+export default function HomeStack() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={Home} options={{ headerShown: false }} />
+      <Stack.Screen name="ReportList" component={ReportList} options={{ title: '실시간 제보' }} />
+      <Stack.Screen
+        name="ReportArticleDetail"
+        component={ReportArticleDetail}
+        options={{ title: '실시간 제보' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/LoggedOutStack.tsx
+++ b/src/navigation/LoggedOutStack.tsx
@@ -1,0 +1,46 @@
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import React from 'react';
+
+import {
+  SignIn,
+  SignUp,
+  SetName,
+  SelectLocation,
+  DisasterNotiSettings,
+  CompleteLogin,
+  Onboarding,
+} from '../pages';
+import { LoggedOutStackParamList } from './types';
+
+const Stack = createNativeStackNavigator<LoggedOutStackParamList>();
+
+export default function LoggedOutStack() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Onboarding" component={Onboarding} options={{ headerShown: false }} />
+      {/* 테스트 위해 임시로 설정한거 */}
+      <Stack.Screen
+        name="DisasterNotiSettings"
+        component={DisasterNotiSettings}
+        options={{ title: '알림 설정' }}
+      />
+      <Stack.Screen
+        name="SignIn"
+        component={SignIn}
+        options={{ headerShown: false, title: '로그인' }}
+      />
+      <Stack.Screen name="SignUp" component={SignUp} options={{ title: '회원가입' }} />
+      <Stack.Screen name="SetName" component={SetName} options={{ title: '닉네임 설정' }} />
+      <Stack.Screen
+        name="SelectLocation"
+        component={SelectLocation}
+        options={{ title: '지역 선택' }}
+      />
+      <Stack.Screen
+        name="CompleteLogin"
+        component={CompleteLogin}
+        options={{ headerShown: false, title: '회원가입 완료' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/RootStackNavigator.tsx
+++ b/src/navigation/RootStackNavigator.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import TabNavigator from './TabNavigator';
+import { RootStackParamList } from './types';
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function RootStackNavigator() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="MainTabNavigator"
+        component={TabNavigator}
+        options={{ headerShown: false }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Solution, Main, ReportPost } from '../pages';
+import { RootTabParamList } from './types';
+
+const Tab = createBottomTabNavigator<RootTabParamList>();
+
+export default function TabNavigator() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Main" component={Main} options={{ headerShown: false, title: '홈' }} />
+      <Tab.Screen name="Report" component={ReportPost} options={{ title: '실시간 제보' }} />
+      <Tab.Screen name="Solution" component={Solution} options={{ title: '솔루션' }} />
+    </Tab.Navigator>
+  );
+}

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -9,7 +9,7 @@ export type LoggedOutStackParamList = {
   DisasterNotiSettings: undefined;
   SignIn: undefined;
   SignUp: undefined;
-  SetName: undefined;
+  SetName: { id: string; email: string; password: string };
   SelectLocation: undefined;
   CompleteLogin: undefined;
 };

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,0 +1,25 @@
+export type HomeStackParamList = {
+  Home: undefined;
+  ReportList: undefined;
+  ReportArticleDetail: undefined;
+};
+
+export type LoggedOutStackParamList = {
+  Onboarding: undefined;
+  DisasterNotiSettings: undefined;
+  SignIn: undefined;
+  SignUp: undefined;
+  SetName: undefined;
+  SelectLocation: undefined;
+  CompleteLogin: undefined;
+};
+
+export type RootStackParamList = {
+  MainTabNavigator: undefined;
+};
+
+export type RootTabParamList = {
+  Main: undefined;
+  Report: undefined;
+  Solution: undefined;
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,6 +7,7 @@ import WeatherSection from '../components/Home/WeatherSection';
 import IssueSection from '../components/Home/IssueSection';
 import AddressBottomSheet from '../components/Home/AddressSetting/AddressBottomSheet';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
+import ReportSection from '../components/Home/ReportSection';
 
 export default function Home() {
   const bottomSheetRef = React.useRef<BottomSheetModal>(null);
@@ -75,6 +76,7 @@ export default function Home() {
               bottomSheetModalRef={bottomSheetRef}
             />
             <IssueSection isLocalSelected={isLocalSelected} />
+            <ReportSection />
           </View>
         </ScrollView>
         <AddressBottomSheet bottomSheetModalRef={bottomSheetRef} />
@@ -87,7 +89,6 @@ const styles = StyleSheet.create({
   layout: {
     width: '100%',
     height: '100%',
-    display: 'flex',
     flexDirection: 'column',
     backgroundColor: `${COLOR.primary}`,
     position: 'relative',
@@ -99,14 +100,11 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     right: 0,
-    display: 'flex',
     flexDirection: 'column',
   },
   contentSheet: {
-    display: 'flex',
     width: '100%',
     height: 3000,
-    alignItems: 'center',
     backgroundColor: `${COLOR.lightGray}`,
     borderTopLeftRadius: 20,
     borderTopRightRadius: 20,

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,8 +8,12 @@ import IssueSection from '../components/Home/IssueSection';
 import AddressBottomSheet from '../components/Home/AddressSetting/AddressBottomSheet';
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
 import ReportSection from '../components/Home/ReportSection';
+import { HomeStackParamList } from '../navigation/types';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
-export default function Home() {
+export type HomeScreenProps = NativeStackScreenProps<HomeStackParamList, 'Home'>;
+
+export default function Home({ navigation }: HomeScreenProps) {
   const bottomSheetRef = React.useRef<BottomSheetModal>(null);
 
   const [isLocalSelected, setLocalSelected] = React.useState<boolean>(false);
@@ -76,7 +80,7 @@ export default function Home() {
               bottomSheetModalRef={bottomSheetRef}
             />
             <IssueSection isLocalSelected={isLocalSelected} />
-            <ReportSection />
+            <ReportSection navigation={navigation} />
           </View>
         </ScrollView>
         <AddressBottomSheet bottomSheetModalRef={bottomSheetRef} />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,7 +13,7 @@ import { NativeStackScreenProps } from '@react-navigation/native-stack';
 
 export type HomeScreenProps = NativeStackScreenProps<HomeStackParamList, 'Home'>;
 
-export default function Home({ navigation }: HomeScreenProps) {
+export default function Home() {
   const bottomSheetRef = React.useRef<BottomSheetModal>(null);
 
   const [isLocalSelected, setLocalSelected] = React.useState<boolean>(false);
@@ -80,7 +80,7 @@ export default function Home({ navigation }: HomeScreenProps) {
               bottomSheetModalRef={bottomSheetRef}
             />
             <IssueSection isLocalSelected={isLocalSelected} />
-            <ReportSection navigation={navigation} />
+            <ReportSection />
           </View>
         </ScrollView>
         <AddressBottomSheet bottomSheetModalRef={bottomSheetRef} />

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import HomeStack from '../navigation/HomeStack';
+
+export default function Main() {
+  return <HomeStack />;
+}

--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -17,6 +17,7 @@ import { DisasterType } from '../components/SelectDisaster/types';
 import ReportArticleCard from '../components/ReportArticle/ReportArticleCard';
 import { ARTICLE_LIST } from '../constants/DummyArticle';
 import { useNavigation } from '@react-navigation/native';
+import ReportArticleList from '../components/ReportArticle/ReportArticleList';
 
 export type ReportScreenProps = NativeStackScreenProps<RootTabParamList, 'Report'>;
 
@@ -147,22 +148,7 @@ export default function Report({ navigation }: ReportScreenProps) {
           </Pressable>
         </View>
 
-        <FlatList
-          data={ARTICLE_LIST}
-          renderItem={({ item }) => (
-            <ReportArticleCard
-              id={item.id}
-              elapsedTime={item.elapsedTime}
-              viewCount={item.viewCount}
-              likeCount={item.likeCount}
-              title={item.title}
-              tags={item.tags}
-            />
-          )}
-          numColumns={1}
-          contentContainerStyle={styles.articleList}
-          scrollEnabled={false}
-        />
+        <ReportArticleList />
 
         {/* 모달 */}
         <SelectRegionBottomSheet
@@ -252,8 +238,5 @@ const styles = StyleSheet.create({
     borderRadius: 50,
     alignItems: 'center',
     justifyContent: 'center',
-  },
-  articleList: {
-    gap: 10,
   },
 });

--- a/src/pages/ReportList.tsx
+++ b/src/pages/ReportList.tsx
@@ -1,25 +1,16 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { FlatList, Pressable, StyleSheet, Text, View, ScrollView } from 'react-native';
+import { Pressable, StyleSheet, Text, View, ScrollView } from 'react-native';
 import { SelectRegionBottomSheet } from '../components/BottomSheetModal';
 
 import { BottomSheetModal } from '@gorhom/bottom-sheet';
-import {
-  NativeStackNavigationOptions,
-  NativeStackScreenProps,
-} from '@react-navigation/native-stack';
-import { RootTabParamList } from '../../App';
+import { NativeStackNavigationOptions } from '@react-navigation/native-stack';
 import COLOR from '../constants/colors';
 import FaIcon from 'react-native-vector-icons/FontAwesome';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import { SigunguAndEupmyeondongType } from '../components/SelectRegion/types';
 import SelectDisasterBottomSheet from '../components/BottomSheetModal/SelectDisasterBottomSheet';
 import { DisasterType } from '../components/SelectDisaster/types';
-import ReportArticleCard from '../components/ReportArticle/ReportArticleCard';
-import { ARTICLE_LIST } from '../constants/DummyArticle';
-import { useNavigation } from '@react-navigation/native';
 import ReportArticleList from '../components/ReportArticle/ReportArticleList';
-
-export type ReportScreenProps = NativeStackScreenProps<RootTabParamList, 'Report'>;
 
 export interface CustomNavigationOptions extends Partial<NativeStackNavigationOptions> {
   tabBarStyle?: {
@@ -27,7 +18,7 @@ export interface CustomNavigationOptions extends Partial<NativeStackNavigationOp
   };
 }
 
-export default function Report({ navigation }: ReportScreenProps) {
+export default function ReportList({ navigation }) {
   const selectRegionModalRef = useRef<BottomSheetModal>(null);
   const selectDisasterModalRef = useRef<BottomSheetModal>(null);
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,8 @@
 export { default as Home } from './Home';
-export { default as Report } from './Report';
+export { default as Onboarding } from './Onboarding';
+export { default as ReportList } from './ReportList';
+export { default as ReportArticleDetail } from './ReportArticleDetail';
+export { default as ReportPost } from './ReportPost';
 export { default as SignIn } from './SignIn';
 export { default as SignUp } from './SignUp';
 export { default as Solution } from './Solution';
@@ -7,4 +10,4 @@ export { default as SelectLocation } from './SelectLocation';
 export { default as SetName } from './SetName';
 export { default as DisasterNotiSettings } from './DisasterNotiSettings';
 export { default as CompleteLogin } from './CompleteLogin';
-export { default as ReportArticleDetail } from './ReportArticleDetail';
+export { default as Main } from './Main';


### PR DESCRIPTION
## 작업 내용

1. 홈 - 제보 - 제보 상세페이지로 이어지는 네비게이션 작업했습니다. 
![ezgif com-video-to-gif (3)](https://github.com/DisasterKok/Disaterkok_frontend/assets/66055587/537df209-fab3-4a89-bb3b-c5d7dbdf8cd7)

2. 해당 작업을 위해 기존의 네비게이션 구조를 중첩이 가능한 네비게이션 구조로 변경 적용했습니다.
- components/navigation에 필요한 Stack, Tab 네비게이션 정의
- components/navigation/LoggedOutStack -> 로그인 안했을 때 보여줄 화면 Stack 정의
- components/navigation/RootStackNavigator -> 로그인 했을 때 보여줄 스택 정의. 재난콕은 바텀탭 기반이므로 해당 컴포넌트의 인자로 Tab들을 정의해놓은 TabNavigator를 인자로 전달했습니다. (Tab도 결국 하나의 스크린을 구성하므로)
- components/navigation/TabNavigator -> BottomTab Navigator 정의
- components/navigation/types.ts -> 각 Stack 화면을 구성하는 리스트 타입 정의

App.tsx 보면서 쭉 읽어보면 이해 될겁니다! 혹시 이해 안되는 부분 있으면 말해주세요.
해당 pr 에서는 홈 화면에서 필요한 (홈 - 제보 상세 or 홈 - 제보리스트 -제보 상세) 이 2가지의 네비게이션 작업을 했습니다. components/navigation/HomeStack.tsx 참고하면 됩니다!

3. 피그마 UI에 맞게 페이지 스택 쌓였을 때 뒤로가기 버튼 디자인에 맞게 작업했습니다. 해당 뒤로가기 버튼은 components/Header/HeaderLeftGoBack 컴포넌트로 제작했습니다. 
 아래 사진과 같이 options으로 값을 전달해주면 됩니다!
![스크린샷 2023-11-09 오후 11 30 08](https://github.com/DisasterKok/Disaterkok_frontend/assets/66055587/990e322f-ee4e-478a-83ce-a9ee384790c3)

## 기타 사항
1. RN에서는 display: 'flex' 가 기본으로 들어가있어서 따로 작성하지 않아도 됩니다! 홈 화면 style 작업하면서 보이는 부분 빼놓긴 했는데, 전부 고친건 아니라 나중에 한 번 정리하면 될 것 같아요. 추후에 작업할 때 참고하시면 될 것 같습니다.